### PR TITLE
Added a Stats non-standard meta-api to provide simple roll-up statistics for current account usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rdoc
 .bundle
 Gemfile.lock
 pkg/*
+.rvmrc

--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,10 @@ and you can nest multiple verbs inside a block:
   }
   verb.response
 
+== Statistics API
+
+This version adds a non-standard meta-api to provide simple roll-up statistics for current account usage
+
 == Installation
 
   gem install twilio
@@ -57,3 +61,4 @@ Copyright (c) 2009-2011 Phil Misiowiec, Webficient LLC. See LICENSE for details.
 * Mark Turner
 * Jeff Wigal
 * Alex K Wolfe
+* Marcus Mateus (http://github.com/marcusmateus)

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require 'irb'
+ARGV.clear
+$: << File.expand_path('../../lib', __FILE__)
+require 'twilio'
+IRB.start

--- a/lib/twilio.rb
+++ b/lib/twilio.rb
@@ -51,4 +51,11 @@ module Twilio
     self.basic_auth account_sid, auth_token
     self.default_options[:ssl_ca_path] ||= SSL_CA_PATH unless self.default_options[:ssl_ca_file]
   end  
+
+  # Quick & dirty way to get proper encoding for 
+  # 'StartTime>', 'StartTime<', etc. query params working
+  query_string_normalizer proc { |query|
+    URI.encode(query.to_params)
+  }
+
 end

--- a/lib/twilio.rb
+++ b/lib/twilio.rb
@@ -55,7 +55,8 @@ module Twilio
   # Quick & dirty way to get proper encoding for 
   # 'StartTime>', 'StartTime<', etc. query params working
   query_string_normalizer proc { |query|
-    URI.encode(query.to_params)
+    params = HashConversions.to_params(query)
+    params.gsub('>', '%3E').gsub('<', '%3C')
   }
 
 end

--- a/lib/twilio.rb
+++ b/lib/twilio.rb
@@ -35,6 +35,7 @@ require 'twilio/notification'
 require 'twilio/outgoing_caller_id'
 require 'twilio/recording'
 require 'twilio/sms'
+require 'twilio/stats'
 require 'twilio/verb'
 
 module Twilio  

--- a/lib/twilio/stats.rb
+++ b/lib/twilio/stats.rb
@@ -1,0 +1,48 @@
+module Twilio
+  # Stats class creates a non-standard meta-api to provide simple roll-up
+  # statistics for current account usage
+  class Stats < TwilioObject
+    # Returns a hash with aggregate count, duration, and price
+    # statistics for each "from" phone number, as well as a total
+    # across all numbers. -- Makes most sense for outbound apps
+    # TODO refactor this
+    def calls(options = {})
+      options = {:PageSize => 1000}.merge(options)
+      stats = {}
+      page = 0
+      numpages = -1
+      while page != numpages do
+        resp = Twilio::Call.list(options.merge({:page => page})).parsed_response['TwilioResponse']['Calls']
+        page = resp['page'].to_i + 1
+        numpages = resp['numpages'].to_i
+        resp['Call'].each do |call|
+          from_phone_num = call['From']
+          unless stats[from_phone_num] 
+            stats[from_phone_num] = {}
+            stats[from_phone_num][:count] = 0
+            stats[from_phone_num][:duration] = 0
+            stats[from_phone_num][:price] = 0
+          end
+          stats[from_phone_num][:count] += 1 unless call['ParentCallSid']
+          stats[from_phone_num][:duration] += call['Duration'].to_i
+          stats[from_phone_num][:price] += (call['Price'].to_f * 100).to_i
+        end
+      end
+      
+      total_count = 0
+      total_duration = 0
+      total_price = 0
+      stats.each do |num, info|
+        total_count += info[:count]
+        total_duration += info[:duration]
+        total_price += info[:price]
+      end
+      stats[:total_count] = total_count
+      stats[:total_duration] = total_duration
+      stats[:total_price] = total_price
+
+      stats
+    end
+  end
+end
+

--- a/lib/twilio/stats.rb
+++ b/lib/twilio/stats.rb
@@ -21,24 +21,29 @@ module Twilio
             stats[from_phone_num] = {}
             stats[from_phone_num][:count] = 0
             stats[from_phone_num][:duration] = 0
+            stats[from_phone_num][:minutes_charged] = 0
             stats[from_phone_num][:price] = 0
           end
           stats[from_phone_num][:count] += 1 unless call['ParentCallSid']
           stats[from_phone_num][:duration] += call['Duration'].to_i
+          stats[from_phone_num][:minutes_charged] += (call['Duration'].to_i / 60.0).ceil
           stats[from_phone_num][:price] += (call['Price'].to_f * 100).to_i
         end
       end
       
       total_count = 0
       total_duration = 0
+      total_minutes_charged = 0
       total_price = 0
       stats.each do |num, info|
         total_count += info[:count]
         total_duration += info[:duration]
+        total_minutes_charged += info[:minutes_charged]
         total_price += info[:price]
       end
       stats[:total_count] = total_count
       stats[:total_duration] = total_duration
+      stats[:total_minutes_charged] = total_minutes_charged
       stats[:total_price] = total_price
 
       stats

--- a/spec/fixtures/xml/available_phone_numbers_local.xml
+++ b/spec/fixtures/xml/available_phone_numbers_local.xml
@@ -1,4 +1,4 @@
-TwilioResponse>
+<TwilioResponse>
     <AvailablePhoneNumbers uri="/2010-04-01/Accounts/ACde6f1e11047ebd6fe7a55f120be3a900/AvailablePhoneNumbers/US/Local?AreaCode=510">
         <AvailablePhoneNumber>
             <FriendlyName>(510) 564-7903</FriendlyName>

--- a/spec/fixtures/xml/calls_pg0.xml
+++ b/spec/fixtures/xml/calls_pg0.xml
@@ -1,0 +1,36 @@
+<TwilioResponse>  
+  <Calls page="0" numpages="2" pagesize="2" total="4" start="0" end="1">  
+    <Call>  
+      <Sid>CA42ed11f93dc08b952027ffbc406d0868</Sid>  
+      <DateCreated>Sat, 07 Feb 2009 13:15:19 -0800</DateCreated>
+      <DateUpdated>Sat, 07 Feb 2009 13:15:19 -0800</DateUpdated>
+      <CallSegmentSid/>  
+      <AccountSid>mysid</AccountSid>  
+      <To>4159633717</To>  
+      <From>4156767950</From>  
+      <PhoneNumberSid>PN01234567890123456789012345678900</PhoneNumberSid>  
+      <Status>2</Status>  
+      <StartTime>Thu, 03 Apr 2008 04:36:33 -0400</StartTime>  
+      <EndTime>Thu, 03 Apr 2008 04:36:47 -0400</EndTime>  
+      <Duration>15</Duration>  
+      <Price>0.3</Price>  
+      <Flags>1</Flags>  
+    </Call>  
+    <Call>  
+      <Sid>CA751e8fa0a0105cf26a0d7a9775fb4bfb</Sid>  
+      <DateCreated>Sat, 07 Feb 2009 13:15:19 -0800</DateCreated>
+      <DateUpdated>Sat, 07 Feb 2009 13:15:19 -0800</DateUpdated>
+      <CallSegmentSid/>  
+      <AccountSid>mysid</AccountSid>  
+      <To>2064287985</To>  
+      <From>4156767950</From>  
+      <PhoneNumberSid>PNd59c2ba27ef48264773edb90476d1674</PhoneNumberSid>  
+      <Status>2</Status>  
+      <StartTime>Thu, 03 Apr 2008 01:37:05 -0400</StartTime>  
+      <EndTime>Thu, 03 Apr 2008 01:37:40 -0400</EndTime>  
+      <Duration>35</Duration>  
+      <Price>0.7</Price>  
+      <Flags>1</Flags>  
+    </Call>  
+   </Calls> 
+</TwilioResponse>

--- a/spec/fixtures/xml/calls_pg1.xml
+++ b/spec/fixtures/xml/calls_pg1.xml
@@ -1,0 +1,36 @@
+<TwilioResponse>  
+  <Calls page="1" numpages="2" pagesize="2" total="4" start="2" end="3">  
+    <Call>  
+      <Sid>CA751e8fa0a0105cf26a0d7a9775fb4bfc</Sid>  
+      <DateCreated>Sat, 07 Feb 2009 14:15:19 -0800</DateCreated>
+      <DateUpdated>Sat, 07 Feb 2009 14:15:19 -0800</DateUpdated>
+      <CallSegmentSid/>  
+      <AccountSid>mysid</AccountSid>  
+      <To>2064287985</To>  
+      <From>4156767975</From>  
+      <PhoneNumberSid>PNd59c2ba27ef48264773edb90476d1700</PhoneNumberSid>  
+      <Status>2</Status>  
+      <StartTime>Thu, 03 Apr 2008 02:37:05 -0400</StartTime>  
+      <EndTime>Thu, 03 Apr 2008 02:37:45 -0400</EndTime>  
+      <Duration>40</Duration>  
+      <Price>0.8</Price>  
+      <Flags>1</Flags>  
+    </Call>  
+     <Call>  
+      <Sid>CA751e8fa0a0105cf26a0d7a9775fb4bfd</Sid>  
+      <DateCreated>Sat, 07 Feb 2009 15:15:19 -0800</DateCreated>
+      <DateUpdated>Sat, 07 Feb 2009 15:15:19 -0800</DateUpdated>
+      <CallSegmentSid/>  
+      <AccountSid>mysid</AccountSid>  
+      <To>2064287985</To>  
+      <From>4156767975</From>  
+      <PhoneNumberSid>PNd59c2ba27ef48264773edb90476d1674</PhoneNumberSid>  
+      <Status>2</Status>  
+      <StartTime>Thu, 03 Apr 2008 03:37:05 -0400</StartTime>  
+      <EndTime>Thu, 03 Apr 2008 03:37:50 -0400</EndTime>  
+      <Duration>45</Duration>  
+      <Price>0.9</Price>  
+      <Flags>1</Flags>  
+    </Call>  
+   </Calls> 
+</TwilioResponse>

--- a/spec/fixtures/xml/notification.xml
+++ b/spec/fixtures/xml/notification.xml
@@ -12,7 +12,7 @@
 		<MessageDate>Thu, 03 Apr 2008 04:36:32 -0400</MessageDate>
 		<RequestURL>http://yourserver.com/handleCall.php</RequestURL>
 		<RequestMethod>POST</RequestMethod>
-		<RequestVariables>From=4158675309&To=4155551212...</RequestVariables>
+		<RequestVariables>From=4158675309&amp;To=4155551212...</RequestVariables>
 		<ResponseHeaders>Content-Length: 500</ResponseHeaders>
 		<ResponseBody>&lt;h1&gt;Error parsing PHP script&lt;/h1&gt;</ResponseBody>
 	</Notification> 

--- a/spec/support/twilio_helpers.rb
+++ b/spec/support/twilio_helpers.rb
@@ -9,13 +9,15 @@ module TwilioHelpers #:nodoc:
     fake_response = fixture(fixture_name)         
     url = twilio_url(resource)
     
+    # Must set header content-type so HTTParty properly parses response
     if request_options
-      stub_request(http_method, url).with(request_options).to_return(:body => fake_response)
+      stub_request(http_method, url).with(request_options).to_return(:body => fake_response, :headers => {:content_type => 'application/xml'})
     else
-      stub_request(http_method, url).to_return(:body => fake_response)
+      stub_request(http_method, url).to_return(:body => fake_response, :headers => {:content_type => 'application/xml'})
     end
     
-    return fake_response, url
+    # Return a parsed response, so it agrees w/ what is retturned from HTTParty
+    return HTTParty::Parser.call(fake_response, :xml), url
   end
     
   def stub_get(fixture, *opts)

--- a/spec/twilio/available_phone_numbers_spec.rb
+++ b/spec/twilio/available_phone_numbers_spec.rb
@@ -28,7 +28,7 @@ describe "Available Phone Numbers" do
     end
     
     it "is searchable using multiple parameters" do      
-      response, url = stub_get(:available_phone_numbers_local_search, 'AvailablePhoneNumbers/US/Local?NearLatLong=37.806940%2C-122.270360&InRateCenter=OKLD0349T&NearNumber=15105551213&Distance=50&InRegion=CA&InLata=722&Contains=510555****')
+      response, url = stub_get(:available_phone_numbers_local_search, 'AvailablePhoneNumbers/US/Local?Contains=510555****&Distance=50&InLata=722&InRateCenter=OKLD0349T&InRegion=CA&NearLatLong=37.806940%252C-122.270360&NearNumber=15105551213')
       
       Twilio::AvailablePhoneNumbers.search_local(:in_region => 'CA', :contains => '510555****', :near_lat_long => '37.806940,-122.270360', :near_number => '15105551213', :in_lata => 722, :in_rate_center => 'OKLD0349T', :distance => 50).should == response
       WebMock.should have_requested(:get, url)

--- a/spec/twilio/stats_spec.rb
+++ b/spec/twilio/stats_spec.rb
@@ -9,7 +9,7 @@ describe "Stats" do
     response0, url0 = stub_get(:calls_pg0, 'Calls', :query => {:PageSize => '2', :page => '0'})
     response1, url1 = stub_get(:calls_pg1, 'Calls', :query => {:PageSize => '2', :page => '1'})
     
-    Twilio::Stats.calls(:PageSize => 2).should == {"4156767950"=>{:count=>2, :duration=>50, :price=>100}, "4156767975"=>{:count=>2, :duration=>85, :price=>170}, :total_count=>4, :total_duration=>135, :total_price=>270}
+    Twilio::Stats.calls(:PageSize => 2).should == {"4156767950"=>{:count=>2, :duration=>50, :minutes_charged=>2, :price=>100}, "4156767975"=>{:count=>2, :duration=>85, :minutes_charged=>2, :price=>170}, :total_count=>4, :total_duration=>135, :total_minutes_charged=>4, :total_price=>270}
     WebMock.should have_requested(:get, url0).with(:query => {:PageSize => '2', :page => '0'})
     WebMock.should have_requested(:get, url1).with(:query => {:PageSize => '2', :page => '1'})
   end

--- a/spec/twilio/stats_spec.rb
+++ b/spec/twilio/stats_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "Stats" do
+  before(:all) do
+    Twilio.connect('mysid', 'mytoken')
+  end
+  
+  it "gets summary stats for calls in current account" do
+    response0, url0 = stub_get(:calls_pg0, 'Calls', :query => {:PageSize => '2', :page => '0'})
+    response1, url1 = stub_get(:calls_pg1, 'Calls', :query => {:PageSize => '2', :page => '1'})
+    
+    Twilio::Stats.calls(:PageSize => 2).should == {"4156767950"=>{:count=>2, :duration=>50, :price=>100}, "4156767975"=>{:count=>2, :duration=>85, :price=>170}, :total_count=>4, :total_duration=>135, :total_price=>270}
+    WebMock.should have_requested(:get, url0).with(:query => {:PageSize => '2', :page => '0'})
+    WebMock.should have_requested(:get, url1).with(:query => {:PageSize => '2', :page => '1'})
+  end
+  
+end
+

--- a/twilio.gemspec
+++ b/twilio.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "builder", "~> 2.1.2"
-  s.add_dependency "httparty", "~> 0.7.4"
+  s.add_dependency "httparty", ">= 0.8"
 
   {
     'rake'    => '~> 0.8.7',


### PR DESCRIPTION
- Currently Stats only supports calls, and provides aggregates for each
  'from' phone# & across all calls... easily extended/modified though
- Includes rspec tests
